### PR TITLE
Add use_ssl and verify_ssl to s3 store

### DIFF
--- a/polystores/clients/aws_client.py
+++ b/polystores/clients/aws_client.py
@@ -31,6 +31,17 @@ def get_endpoint_url(keys=None):
     return get_from_env(keys)
 
 
+def get_aws_use_ssl(keys=None):
+    keys = keys or ['AWS_USE_SSL']
+    return get_from_env(keys)
+
+
+def get_aws_verify_ssl(keys=None):
+    keys = ['AWS_VERIFY_SSL'] if keys is None else keys
+    env = get_from_env(keys)
+    return False if env == 'False' else env
+
+
 def get_aws_session(aws_access_key_id=None,
                     aws_secret_access_key=None,
                     aws_session_token=None,
@@ -51,13 +62,24 @@ def get_aws_client(client_type,
                    aws_access_key_id=None,
                    aws_secret_access_key=None,
                    aws_session_token=None,
-                   region_name=None):
+                   region_name=None,
+                   aws_use_ssl=True,
+                   aws_verify_ssl=None):
     session = get_aws_session(aws_access_key_id=aws_access_key_id,
                               aws_secret_access_key=aws_secret_access_key,
                               aws_session_token=aws_session_token,
                               region_name=region_name)
     endpoint_url = endpoint_url or get_endpoint_url()
-    return session.client(client_type, endpoint_url=endpoint_url)
+    aws_use_ssl = aws_use_ssl or get_aws_use_ssl()
+    if aws_verify_ssl is None:
+        aws_verify_ssl = get_aws_verify_ssl()
+    else:
+        aws_verify_ssl = aws_verify_ssl
+    return session.client(
+        client_type,
+        endpoint_url=endpoint_url,
+        use_ssl=aws_use_ssl,
+        verify=aws_verify_ssl)
 
 
 def get_aws_resource(resource_type,
@@ -65,10 +87,21 @@ def get_aws_resource(resource_type,
                      aws_access_key_id=None,
                      aws_secret_access_key=None,
                      aws_session_token=None,
-                     region_name=None):
+                     region_name=None,
+                     aws_use_ssl=True,
+                     aws_verify_ssl=None):
     session = get_aws_session(aws_access_key_id=aws_access_key_id,
                               aws_secret_access_key=aws_secret_access_key,
                               aws_session_token=aws_session_token,
                               region_name=region_name)
     endpoint_url = endpoint_url or get_endpoint_url()
-    return session.resource(resource_type, endpoint_url=endpoint_url)
+    aws_use_ssl = aws_use_ssl or get_aws_use_ssl()
+    if aws_verify_ssl is None:
+        aws_verify_ssl = get_aws_verify_ssl()
+    else:
+        aws_verify_ssl = aws_verify_ssl
+    return session.resource(
+        resource_type,
+        endpoint_url=endpoint_url,
+        use_ssl=aws_use_ssl,
+        verify=aws_verify_ssl)

--- a/polystores/stores/s3_store.py
+++ b/polystores/stores/s3_store.py
@@ -48,6 +48,12 @@ class S3Store(BaseStore):
         self._region_name = (kwargs.get('region') or
                              kwargs.get('aws_region') or
                              kwargs.get('AWS_REGION'))
+        self._aws_verify_ssl = kwargs.get('verify_ssl',
+                                          kwargs.get('aws_verify_ssl',
+                                                     kwargs.get('AWS_VERIFY_SSL', None)))
+        self._aws_use_ssl = (kwargs.get('use_ssl') or
+                             kwargs.get('aws_use_ssl') or
+                             kwargs.get('AWS_USE_SSL'))
 
     @property
     def client(self):
@@ -56,7 +62,9 @@ class S3Store(BaseStore):
                             aws_access_key_id=self._aws_access_key_id,
                             aws_secret_access_key=self._aws_secret_access_key,
                             aws_session_token=self._aws_session_token,
-                            region_name=self._region_name)
+                            region_name=self._region_name,
+                            aws_use_ssl=self._aws_use_ssl,
+                            aws_verify_ssl=self._aws_verify_ssl)
         return self._client
 
     def set_env_vars(self):
@@ -70,6 +78,10 @@ class S3Store(BaseStore):
             os.environ['AWS_SECURITY_TOKEN'] = self._aws_session_token
         if self._region_name:
             os.environ['AWS_REGION'] = self._region_name
+        if self._aws_use_ssl is not None:
+            os.environ['AWS_USE_SSL'] = self._aws_use_ssl
+        if self._aws_verify_ssl is not None:
+            os.environ['AWS_VERIFY_SSL'] = self._aws_verify_ssl
 
     @property
     def resource(self):
@@ -86,7 +98,9 @@ class S3Store(BaseStore):
                    aws_access_key_id=None,
                    aws_secret_access_key=None,
                    aws_session_token=None,
-                   region_name=None):
+                   region_name=None,
+                   aws_use_ssl=True,
+                   aws_verify_ssl=None):
         """
         Sets a new s3 boto3 client.
 
@@ -107,7 +121,9 @@ class S3Store(BaseStore):
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
-            region_name=region_name)
+            region_name=region_name,
+            aws_use_ssl=aws_use_ssl,
+            aws_verify_ssl=aws_verify_ssl)
 
     def set_resource(self,
                      endpoint_url=None,


### PR DESCRIPTION
Adds the AWS_USE_SSL and AWS_VERIFY_SSL flags to the aws_client and
aws_store in order to allow connections to alternative s3 clients
without valid certificate.

Resolves https://github.com/polyaxon/polystores/issues/1