### PR TITLE
Add AWS legacy api override

### DIFF
--- a/polystores/clients/aws_client.py
+++ b/polystores/clients/aws_client.py
@@ -38,8 +38,17 @@ def get_aws_use_ssl(keys=None):
 
 def get_aws_verify_ssl(keys=None):
     keys = ['AWS_VERIFY_SSL'] if keys is None else keys
-    env = get_from_env(keys)
-    return False if env == 'False' else env
+    return get_from_env(keys)
+
+
+def get_aws_legacy_api(keys=None):
+    keys = keys or ['AWS_LEGACY_API']
+    return get_from_env(keys)
+
+
+def get_legacy_api(legacy_api=False):
+    legacy_api = legacy_api or get_aws_legacy_api()
+    return legacy_api
 
 
 def get_aws_session(aws_access_key_id=None,

--- a/polystores/utils.py
+++ b/polystores/utils.py
@@ -26,6 +26,10 @@ def get_from_env(keys):
     for key in keys:
         value = os.environ.get(key)
         if value:
+            if value.lower() == 'true':
+                return True
+            if value.lower() == 'false':
+                return False
             return value
         # Prepend POLYAXON
         key = 'POLYAXON_{}'.format(key)


### PR DESCRIPTION
Adds ability to override the aws api to older version. Currently only
overrides the version of list-objects api used.

Resolves https://github.com/polyaxon/polystores/issues/3