### PR TITLE
Change to recursive directory creation in stores

### DIFF
--- a/polystores/stores/azure_store.py
+++ b/polystores/stores/azure_store.py
@@ -244,7 +244,7 @@ class AzureStore(BaseStore):
         try:
             check_dirname_exists(local_path, is_dir=True)
         except PolyaxonStoresException:
-            os.mkdir(local_path)
+            os.makedirs(local_path)
 
         results = self.list(container_name=container_name, key=blob, delimiter='/')
 

--- a/polystores/stores/gcs_store.py
+++ b/polystores/stores/gcs_store.py
@@ -299,7 +299,7 @@ class GCSStore(BaseStore):
         try:
             check_dirname_exists(local_path, is_dir=True)
         except PolyaxonStoresException:
-            os.mkdir(local_path)
+            os.makedirs(local_path)
 
         results = self.list(bucket_name=bucket_name, key=blob, delimiter='/')
 

--- a/polystores/stores/s3_store.py
+++ b/polystores/stores/s3_store.py
@@ -554,7 +554,7 @@ class S3Store(BaseStore):
         try:
             check_dirname_exists(local_path, is_dir=True)
         except PolyaxonStoresException:
-            os.mkdir(local_path)
+            os.makedirs(local_path)
 
         results = self.list(bucket_name=bucket_name, prefix=key, delimiter='/')
 


### PR DESCRIPTION
Changes to using os.makedirs instead of os.mkdir in the stores.
See https://docs.python.org/3.6/library/os.html#os.makedirs

Fixes: https://github.com/polyaxon/polystores/issues/6

Tested on python 3.6 and 2.7 with AWS S3.