### PR TITLE
Use relative paths for ls.

### DIFF
--- a/polystores/stores/manager.py
+++ b/polystores/stores/manager.py
@@ -48,9 +48,13 @@ class StoreManager(object):
         return self._path
 
     def ls(self, path):
+        if self._path:  # We assume rel paths
+            path = os.path.join(self._path, path)
         return self.store.ls(path)
 
     def list(self, path):
+        if self._path:  # We assume rel paths
+            path = os.path.join(self._path, path)
         return self.store.list(path)
 
     def delete(self, path):


### PR DESCRIPTION
To be consistent with the [download_file]() and [download_dir](https://github.com/polyaxon/polystores/compare/master...ahoereth:rel_ls?expand=1#diff-37a9668290e0afb374bd9ac4b494706fR80) behaviour, `ls` and `list` should also default to relative paths. The current behaviour of expecting relative paths for the download methods but absolute paths for the other appears to be undocumented?