### PR TITLE
Parse full S3 path into bucket and prefix

### DIFF
--- a/polystores/stores/s3_store.py
+++ b/polystores/stores/s3_store.py
@@ -204,8 +204,8 @@ class S3Store(BaseStore):
         return self.resource.Bucket(bucket_name)
 
     def ls(self, path):
-        (bucket, prefix) = self.parse_s3_url(path)
-        results = self.list(bucket_name=bucket, prefix=prefix)
+        (bucket_name, key) = self.parse_s3_url(path)
+        results = self.list(bucket_name=bucket_name, prefix=key)
         return {'files': results['keys'], 'dirs': results['prefixes']}
 
     def list(self,

--- a/polystores/stores/s3_store.py
+++ b/polystores/stores/s3_store.py
@@ -204,16 +204,7 @@ class S3Store(BaseStore):
         return self.resource.Bucket(bucket_name)
 
     def ls(self, path):
-        # Strip out any unnecessary characters
-        stripped = path.replace('s3://', '').rstrip('/')
-        try:
-            # If a prefix is part of the path, extract it
-            bucket, prefix = stripped.split("/", 2)
-        except ValueError:
-            # The path was only a bucket name so we'll just use that
-            bucket = stripped
-            prefix = ''
-
+        (bucket, prefix) = self.parse_s3_url(path)
         results = self.list(bucket_name=bucket, prefix=prefix)
         return {'files': results['keys'], 'dirs': results['prefixes']}
 

--- a/polystores/stores/s3_store.py
+++ b/polystores/stores/s3_store.py
@@ -204,7 +204,17 @@ class S3Store(BaseStore):
         return self.resource.Bucket(bucket_name)
 
     def ls(self, path):
-        results = self.list(bucket_name=path)
+        # Strip out any unnecessary characters
+        stripped = path.replace('s3://', '').rstrip('/')
+        try:
+            # If a prefix is part of the path, extract it
+            bucket, prefix = stripped.split("/", 2)
+        except ValueError:
+            # The path was only a bucket name so we'll just use that
+            bucket = stripped
+            prefix = ''
+
+        results = self.list(bucket_name=bucket, prefix=prefix)
         return {'files': results['keys'], 'dirs': results['prefixes']}
 
     def list(self,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 
 setup(name='polystores',
-      version='0.1.8',
+      version='0.1.9',
       description='Polystores is an abstraction and a collection of clients '
                   'to interact with cloud storages.',
       long_description=read_readme(),

--- a/tests/test_stores/test_s3_store.py
+++ b/tests/test_stores/test_s3_store.py
@@ -95,16 +95,10 @@ class TestAwsStore(TestCase):
         empty_response = {'dirs': [], 'files': []}
         dir_response = {'dirs': [], 'files': [('/b', 1)]}
 
-        assert store.ls('bucket') == full_response
-        assert store.ls('bucket/') == full_response
         assert store.ls('s3://bucket') == full_response
         assert store.ls('s3://bucket/') == full_response
-        assert store.ls('bucket/non-existent') == empty_response
-        assert store.ls('bucket/non-existent/') == empty_response
         assert store.ls('s3://bucket/non-existent') == empty_response
         assert store.ls('s3://bucket/non-existent/') == empty_response
-        assert store.ls('bucket/dir') == dir_response
-        assert store.ls('bucket/dir/') == dir_response
         assert store.ls('s3://bucket/dir') == dir_response
         assert store.ls('s3://bucket/dir/') == dir_response
 

--- a/tests/test_stores/test_s3_store.py
+++ b/tests/test_stores/test_s3_store.py
@@ -84,6 +84,31 @@ class TestAwsStore(TestCase):
         assert store.list_keys(bucket_name='bucket', prefix='dir/') == [('b', 1)]
 
     @mock_s3
+    def test_ls(self):
+        store = S3Store()
+        b = store.get_bucket('bucket')
+        b.create()
+        b.put_object(Key='a', Body=b'a')
+        b.put_object(Key='dir/b', Body=b'b')
+
+        full_response = {'dirs': [], 'files': [('a', 1), ('dir/b', 1)]}
+        empty_response = {'dirs': [], 'files': []}
+        dir_response = {'dirs': [], 'files': [('/b', 1)]}
+
+        assert store.ls('bucket') == full_response
+        assert store.ls('bucket/') == full_response
+        assert store.ls('s3://bucket') == full_response
+        assert store.ls('s3://bucket/') == full_response
+        assert store.ls('bucket/non-existent') == empty_response
+        assert store.ls('bucket/non-existent/') == empty_response
+        assert store.ls('s3://bucket/non-existent') == empty_response
+        assert store.ls('s3://bucket/non-existent/') == empty_response
+        assert store.ls('bucket/dir') == dir_response
+        assert store.ls('bucket/dir/') == dir_response
+        assert store.ls('s3://bucket/dir') == dir_response
+        assert store.ls('s3://bucket/dir/') == dir_response
+
+    @mock_s3
     def test_delete(self):
         store = S3Store()
         b = store.get_bucket('bucket')


### PR DESCRIPTION
Fixed #12 
I was having an issue with S3 outputs displaying in the UI that seemed to be due to the `ls` function for the S3 Store. https://github.com/polyaxon/polyaxon/blob/0.4.4/polyaxon/api/experiments/views.py#L430

Played around with it directly and was consistently getting `ParamValidationError` for invalid bucket name. Wrote up the test case in this PR to confirm.
<img width="781" alt="Screen Shot 2019-06-24 at 12 49 32 PM" src="https://user-images.githubusercontent.com/2559160/60044197-76d60680-9687-11e9-95ed-a0f9b7f03a2a.png">

Wrote just a little bit of logic to parse out the actual bucket name and prefix from the given path since that's all the `ls` function has access to. After including the change, the new and all existing tests were passing. 
<img width="773" alt="Screen Shot 2019-06-24 at 12 54 34 PM" src="https://user-images.githubusercontent.com/2559160/60044196-76d60680-9687-11e9-9419-1ab9e5b85dcd.png">